### PR TITLE
Add explanation for users with different keyboard layouts

### DIFF
--- a/README
+++ b/README
@@ -2,6 +2,16 @@ LILYQUICK
 
 Welcome to LilyQuick, originally written as a replacement for Speedy Note Entry when I moved from Finale to Lilypond, and then much improved. The basic idea is to play notes on a MIDI keyboard with your left hand, then while they are sounding, press a note on the numeric keypad with your right hand corresponding to the duration. For example, to get "f2", play an F on the MIDI keyboard, and press number 5 on the numeric keypad. The advantage to this approach is excellent speed and accuracy, and you get to hear the notes as they are being entered.
 
+DIFFERENT KEYBOARD LAYOUTS
+
+Currently LilyQuick only supports QWERTY and with some keyboard layouts this causes problems,
+for example you get German umlauts instead of "'".
+
+You can look up your current layout by typing
+"setxkbmap -query".
+You can change your current layout to "us" which is suitable for LilyQuick by typing
+"setxkbmap us".
+
 VIDEO
 
 I did a demonstration video that you can watch at https://youtu.be/eh8mgF1CNAo


### PR DESCRIPTION
I stumbled across a problem where LilyQuick would enter "ä" instead of "'" and it took me a while to figure it out so I thought it would be nice if the README mentioned that a bit more prominent. Feel free to reword it, put the info somewhere else etc.